### PR TITLE
Fixes git-revision-date-localized plugin

### DIFF
--- a/.github/workflows/deploy_guides.yml
+++ b/.github/workflows/deploy_guides.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         # Or use mhausenblas/mkdocs-deploy-gh-pages@nomaterial to build without the mkdocs-material theme


### PR DESCRIPTION
Locally, the `git-revision-date-localized` plugin works just fine, but every time it's deployed on gh pages this timer gets reseted to 0s, now it works as it should

![image](https://github.com/rathena/user-guides/assets/7357354/8f52e6e8-44a1-423a-b996-4e4a73387e94)
